### PR TITLE
Total cost function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,18 +30,23 @@ The cost incurred by labelling as positive is calculated as:
 ### Expected Cost
 The expected cost is typically a representation of how much a set of data points can be expected to cost a business. It is represented by the symbol *E*. The equation for *E* is as follows:
 
-![Expected Cost](https://raw.githubusercontent.com/mikesiers/DataCost.py/master/readmeImg/ExpectedCost.gif)
+![Expected Cost](https://raw.githubusercontent.com/mikesiers/DataCost/master/readmeImg/ExpectedCost.gif)
 
 ### Expected Cost After Split
 After a split, a set of data points has several new sets of class supports, one for each split. The expected cost difference can be calculated as the difference between *E* for the original dataset, and the summed *E* over all splits. The equation for expected cost after a split is as follows:
 
-![Expected Cost After Split](https://raw.githubusercontent.com/mikesiers/DataCost.py/master/readmeImg/ExpectedCostAfterSplit.gif)
+![Expected Cost After Split](https://raw.githubusercontent.com/mikesiers/DataCost/master/readmeImg/ExpectedCostAfterSplit.gif)
 
 Where *k* is the number of splits, C<sub>P</sub><sup>i</sup> is the value of C<sub>P</sub> for the *i*'th split.
 
 ### Expected Cost Per Record
 The expected cost per data point is simply the expected cost for a dataset divided by the number of data points in the dataset. It is a way of normalizing expected cost such that logical comparisons may be made between the expected cost of two datasets of different size.
 
-![Expected Cost Per Data Point](https://raw.githubusercontent.com/mikesiers/DataCost.py/master/readmeImg/ExpectedCostPerDataPoint.gif)
+![Expected Cost Per Data Point](https://raw.githubusercontent.com/mikesiers/DataCost/master/readmeImg/ExpectedCostPerDataPoint.gif)
 
 Where |*D*| is the number of records in the dataset *D*. 
+
+### Total Cost ###
+The total cost for a set of records is calculated as either *C*<sub>*N*</sub> or *C*<sub>*P*</sub>, whichever is lowest.
+
+*C*<sub>T</sub> = min(*C*<sub>*N*</sub>, *C*<sub>*P*</sub>)

--- a/docs/datacost.html
+++ b/docs/datacost.html
@@ -95,5 +95,18 @@ Returns:<br>
 Raises:<br>
 &nbsp;&nbsp;TypeError:&nbsp;If&nbsp;an&nbsp;incorrect&nbsp;number&nbsp;of&nbsp;arguments&nbsp;are&nbsp;passed.<br>
 &nbsp;&nbsp;KeyError:&nbsp;If&nbsp;the&nbsp;passed&nbsp;cost_matrix&nbsp;is&nbsp;missing&nbsp;a&nbsp;cost.</tt></dd></dl>
+ <dl><dt><a name="-total_cost"><strong>total_cost</strong></a>(num_positive, num_negative, cost_matrix)</dt><dd><tt>Used&nbsp;to&nbsp;calculate&nbsp;the&nbsp;total&nbsp;cost&nbsp;of&nbsp;the&nbsp;set&nbsp;of&nbsp;data&nbsp;points.<br>
+&nbsp;<br>
+Args:<br>
+&nbsp;&nbsp;num_positive&nbsp;(int):&nbsp;The&nbsp;number&nbsp;of&nbsp;positive&nbsp;data&nbsp;points.<br>
+&nbsp;&nbsp;num_negative&nbsp;(int):&nbsp;The&nbsp;number&nbsp;of&nbsp;negative&nbsp;data&nbsp;points.<br>
+&nbsp;&nbsp;cost_matrix&nbsp;(dict):&nbsp;Every&nbsp;cost.&nbsp;e.g.,&nbsp;{'TP':1,&nbsp;'TN':0,&nbsp;'FP':1,&nbsp;'FN':5}<br>
+&nbsp;<br>
+Returns:<br>
+&nbsp;&nbsp;(num):&nbsp;The&nbsp;total&nbsp;cost&nbsp;of&nbsp;the&nbsp;set&nbsp;of&nbsp;data&nbsp;points.<br>
+&nbsp;<br>
+Raises:<br>
+&nbsp;&nbsp;TypeError:&nbsp;If&nbsp;an&nbsp;incorrect&nbsp;number&nbsp;of&nbsp;arguments&nbsp;are&nbsp;passed.<br>
+&nbsp;&nbsp;KeyError:&nbsp;If&nbsp;the&nbsp;passed&nbsp;cost_matrix&nbsp;is&nbsp;missing&nbsp;a&nbsp;cost.</tt></dd></dl>
 </td></tr></table>
 </body></html>

--- a/src/datacost.py
+++ b/src/datacost.py
@@ -154,3 +154,33 @@ def expected_cost_per_record(num_positive, num_negative, cost_matrix):
   num_data_points = num_positive + num_negative
 
   return expected_cost_all / num_data_points
+
+def total_cost(num_positive, num_negative, cost_matrix):
+  """Used to calculate the total cost of the set of data points.
+
+  Args:
+    num_positive (int): The number of positive data points.
+    num_negative (int): The number of negative data points.
+    cost_matrix (dict): Every cost. e.g., {'TP':1, 'TN':0, 'FP':1, 'FN':5}
+
+  Returns:
+    (num): The total cost of the set of data points.
+
+  Raises:
+    TypeError: If an incorrect number of arguments are passed.
+    KeyError: If the passed cost_matrix is missing a cost.
+
+  """
+  if len(locals()) < 3:
+    raise TypeError('Too few arguments.')
+  elif len(locals()) > 3:
+    raise TypeError('Too many arguments.')
+
+  if any(k not in cost_matrix for k in ('TP', 'TN', 'FP', 'FN')):
+    raise KeyError('A cost is missing from the passed cost matrix.')
+
+  # The total cost is actually equal to the lowest cost out of 1) the cost
+  # of labelling as positive, and 2) the cost of labelling as negative.
+  c_p = cost_labelling_positive(num_positive, num_negative, cost_matrix)
+  c_n = cost_labelling_negative(num_positive, num_negative, cost_matrix)
+  return min(c_p, c_n)

--- a/tests/calculation-tests.py
+++ b/tests/calculation-tests.py
@@ -87,5 +87,18 @@ class test_calculations(unittest.TestCase):
         bad_cost_matrix = {'TP' : 1, 'TN' : 0, 'FP' : 1}
         expected_cost_per_record(2, 3, bad_cost_matrix)
 
+    def test_total_cost(self):
+      # Test that if <3 or >3 arguments are passed, a TypeError is raised.
+      with self.assertRaises(TypeError):
+        total_cost(2, 3)
+        total_cost(2, 3, 7, self.cost_matrix)
+      # Test a simple case with 2 positive and 3 negative data points.
+      self.assertEqual(total_cost(2, 3, self.cost_matrix), 5)
+      # Test that a KeyError is raised when the passed cost_matrix doesn't
+      # contain the required costs.
+      with self.assertRaises(KeyError):
+        bad_cost_matrix = {'TP' : 1, 'TN' : 0, 'FP' : 1}
+        cost_labelling_negative(2, 3, bad_cost_matrix)
+
 if __name__ == '__main__':
     unittest.main(exit=False)

--- a/tests/calculation-tests.py
+++ b/tests/calculation-tests.py
@@ -1,7 +1,8 @@
 import sys
 sys.path.append('../')
 from src.datacost import cost_labelling_positive, cost_labelling_negative,\
-  expected_cost, expected_cost_after_split
+  expected_cost, expected_cost_after_split, expected_cost_per_record,\
+  total_cost
 import unittest
 
 class test_calculations(unittest.TestCase):
@@ -73,32 +74,32 @@ class test_calculations(unittest.TestCase):
         {'Y' : 3, 'N' : 1}]
       expected_cost_after_split(class_supports, bad_cost_matrix)
 
-    def test_expected_cost_per_record(self):
-      # Test that if <3 or >3 arguments are passed, a TypeError is raised.
-      with self.assertRaises(TypeError):
-        expected_cost_per_record(2, 3)
-        expected_cost_per_record(2, 3, 7, self.cost_matrix)
-      # Test a simple case with 2 positive and 3 negative data points.
-      cost = expected_cost_per_record(2, 3, self.cost_matrix)
-      self.assertEqual(round(cost, 5), 1.33333)
-      # Test that a KeyError is raised when the passed cost_matrix doesn't
-      # contain the required costs.
-      with self.assertRaises(KeyError):
-        bad_cost_matrix = {'TP' : 1, 'TN' : 0, 'FP' : 1}
-        expected_cost_per_record(2, 3, bad_cost_matrix)
+  def test_expected_cost_per_record(self):
+    # Test that if <3 or >3 arguments are passed, a TypeError is raised.
+    with self.assertRaises(TypeError):
+      expected_cost_per_record(2, 3)
+      expected_cost_per_record(2, 3, 7, self.cost_matrix)
+    # Test a simple case with 2 positive and 3 negative data points.
+    cost = expected_cost_per_record(2, 3, self.cost_matrix)
+    self.assertEqual(round(cost, 5), 1.33333)
+    # Test that a KeyError is raised when the passed cost_matrix doesn't
+    # contain the required costs.
+    with self.assertRaises(KeyError):
+      bad_cost_matrix = {'TP' : 1, 'TN' : 0, 'FP' : 1}
+      expected_cost_per_record(2, 3, bad_cost_matrix)
 
-    def test_total_cost(self):
-      # Test that if <3 or >3 arguments are passed, a TypeError is raised.
-      with self.assertRaises(TypeError):
-        total_cost(2, 3)
-        total_cost(2, 3, 7, self.cost_matrix)
-      # Test a simple case with 2 positive and 3 negative data points.
-      self.assertEqual(total_cost(2, 3, self.cost_matrix), 5)
-      # Test that a KeyError is raised when the passed cost_matrix doesn't
-      # contain the required costs.
-      with self.assertRaises(KeyError):
-        bad_cost_matrix = {'TP' : 1, 'TN' : 0, 'FP' : 1}
-        cost_labelling_negative(2, 3, bad_cost_matrix)
+  def test_total_cost(self):
+    # Test that if <3 or >3 arguments are passed, a TypeError is raised.
+    with self.assertRaises(TypeError):
+      total_cost(2, 3)
+      total_cost(2, 3, 7, self.cost_matrix)
+    # Test a simple case with 2 positive and 3 negative data points.
+    self.assertEqual(total_cost(2, 3, self.cost_matrix), 5)
+    # Test that a KeyError is raised when the passed cost_matrix doesn't
+    # contain the required costs.
+    with self.assertRaises(KeyError):
+      bad_cost_matrix = {'TP' : 1, 'TN' : 0, 'FP' : 1}
+      cost_labelling_negative(2, 3, bad_cost_matrix)
 
 if __name__ == '__main__':
     unittest.main(exit=False)


### PR DESCRIPTION
**What's Included in this Pull Request**

The total cost of a set of records can now be calculated using the `total_cost` function. Unit tests have been implemented and they all pass. Documentation has been added to the pydoc output and the README. After this pull request is merged, the PyPi package will need to be updated.