### PR TITLE
docs: Update version number and tarball link.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,13 @@ from distutils.core import setup
 setup(
   name = 'DataCost',
   packages = ['src'],
-  version = '1.01',
+  version = '1.02',
   description = 'Calculate cost based metrics about data based on the number\
     of positive and negative data points.',
   author = 'Michael J. Siers',
   author_email = 'mikesiers@live.com',
   url = 'https://github.com/mikesiers/DataCost/',
-  download_url = 'https://github.com/mikesiers/DataCost/archive/1.01.tar.gz',
+  download_url = 'https://github.com/mikesiers/DataCost/archive/1.02.tar.gz',
   keywords = ['cost-sensitive', 'machine-learning', 'data-science'],
   classifiers = []
 )


### PR DESCRIPTION
This is being done so that the PyPi package can be updated to the latest version.

See GitHub Issue #11.